### PR TITLE
ignore audio files in formats other than ogg and m4a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # CHANGELOG
 
+## 1.0.1
+* サポート対象外のフォーマットの音声ファイルが含まれる場合エラーにせず、そのままコピーするように
+* game.json が指定する akashic-runtime のバージョンを 3.7.16-0 に更新
+* `@akashic/tkoolmv-namagame-kit@1.2.4` に更新　
+
 ## 1.0.0
 * 初期リリース

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "tkoolmv-namagame-converter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tkoolmv-namagame-converter",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@akashic/tkoolmv-namagame-kit": "^1.1.3",
+        "@akashic/tkoolmv-namagame-kit": "^1.2.4",
         "@ffmpeg/ffmpeg": "^0.12.10",
         "@ffmpeg/util": "^0.12.1",
         "adm-zip": "^0.5.10",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@akashic/tkoolmv-namagame-kit": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@akashic/tkoolmv-namagame-kit/-/tkoolmv-namagame-kit-1.1.3.tgz",
-      "integrity": "sha512-fscnHT92NPPi64WsouT6+xVvPZ+Jt32OEuDsHMhA6+L3M1rqtvQLmTV0mqlvlxJ5H/TE8keXpmnjFgiX05U+Tg=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@akashic/tkoolmv-namagame-kit/-/tkoolmv-namagame-kit-1.2.4.tgz",
+      "integrity": "sha512-r9OFnK4AYqYssx6aDWvxtlys3w6ZW9RTNbftZ64Ds3vBLMfXXLkffKG5H6tMiLrgxVY3cz5yePlUgJvf9WdIVg=="
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tkoolmv-namagame-converter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ツクールMVコンテンツをニコ生ゲームに変換するアプリの試作版",
   "main": "lib/main/main.js",
   "targets": {
@@ -55,7 +55,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@akashic/tkoolmv-namagame-kit": "^1.1.3",
+    "@akashic/tkoolmv-namagame-kit": "^1.2.4",
     "@ffmpeg/ffmpeg": "^0.12.10",
     "@ffmpeg/util": "^0.12.1",
     "adm-zip": "^0.5.10",


### PR DESCRIPTION
### 概要
ゲームフォルダ中のaudioディレクトリ中にoggとm4a以外のファイルがある場合エラーになってしまうようになっていたので、そのようなファイルがあっても特に何もせずそのままコピーするように対応しました

### やったこと
* サポート対象外(oggとm4a以外)のフォーマットの音声ファイルが含まれる場合エラーにせず、そのままコピーするように
* game.json が指定する akashic-runtime のバージョンを 3.7.16-0 に更新
* `@akashic/tkoolmv-namagame-kit@1.2.4` に更新　