### PR TITLE
uploadToGithubReleases.jsの修正

### DIFF
--- a/build/codeSigning.js
+++ b/build/codeSigning.js
@@ -18,4 +18,10 @@ if (!fs.existsSync(targetFilePath)) {
 	process.exit(1);
 }
 
-sh.exec(`signtool sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a "${targetFilePath}"`);
+const signResult = sh.exec(`signtool sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a "${targetFilePath}"`);
+
+// コード署名に失敗した場合、後続スクリプトを停止させたいのでエラー扱いにする
+if (!signResult || signResult.code !== 0) {
+	console.error(`Could not codesign to "${targetFilePath}"`);
+	process.exit(1);
+}

--- a/build/uploadToGithubReleases.js
+++ b/build/uploadToGithubReleases.js
@@ -12,7 +12,12 @@ const packageJson = require(path.resolve(__dirname, "..", "package.json"));
 
 const version = packageJson["version"];
 const name = packageJson["name"];
-const targetFilePaths = [`${name} Setup ${version}.exe`, `${name} Setup ${version}.exe.blockmap`, "latest.yml"].map(name => {
+// latest.ymlが指定するファイル名に合わせてリネーム
+sh.rm("-Rf", path.join(distDirPath, `${name}-Setup-${version}.exe`));
+sh.rm("-Rf", path.join(distDirPath, `${name}-Setup-${version}.exe.blockmap`));
+sh.mv(path.join(distDirPath, `${name} Setup ${version}.exe`), path.join(distDirPath, `${name}-Setup-${version}.exe`));
+sh.mv(path.join(distDirPath, `${name} Setup ${version}.exe.blockmap`), path.join(distDirPath, `${name}-Setup-${version}.exe.blockmap`));
+const targetFilePaths = [`${name}-Setup-${version}.exe`, `${name}-Setup-${version}.exe.blockmap`, "latest.yml"].map(name => {
 	const filePath = path.join(distDirPath, name);
 	if (!fs.existsSync(filePath)) {
 		console.error(`Not Found: ${filePath}`);

--- a/build/uploadToGithubReleases.js
+++ b/build/uploadToGithubReleases.js
@@ -22,7 +22,8 @@ if (fs.existsSync(path.join(distDirPath, `${name} Setup ${version}.exe.blockmap`
 	sh.rm("-Rf", path.join(distDirPath, `${name}-Setup-${version}.exe.blockmap`));
 	sh.mv(path.join(distDirPath, `${name} Setup ${version}.exe.blockmap`), path.join(distDirPath, `${name}-Setup-${version}.exe.blockmap`));
 }
-// exeファイルをコード署名した影響でハッシュ値が変わってしまっているので、latest.ymlに書かれているハッシュ値を現在のものに書き換える必要がある
+// electron-builder には signtool を使って署名する方法が見当たらない
+// 後付けで signtool でコード署名した影響でハッシュ値が変わってしまっているので、自力で再計算して latest.yml に書かれているハッシュ値を書き換える必要がある
 const sha512Hash = crypto.createHash("sha512");
 const binary = fs.readFileSync(path.join(distDirPath, `${name}-Setup-${version}.exe`));
 sha512Hash.update(binary);


### PR DESCRIPTION
### やったこと
uploadToGithubReleases.jsに以下のような修正を行った
* リリースノートアップロード時のバイナリファイルのファイル名が`${name}.Setup.${version}.exe`なのに対して、latest.ymlが指定するファイル名が`${name}-Setup-${version}.exe`なので、バイナリファイルをそのようにリネーム
* バイナリファイルをコード署名した影響でハッシュ値が変わってしまうので、latest.ymlに書かれているsha512のハッシュ値を書き換え