### PR TITLE
fix runtime zip name to download from github release note

### DIFF
--- a/src/main/util/updateTkoolmvNamagameKitRuntime.ts
+++ b/src/main/util/updateTkoolmvNamagameKitRuntime.ts
@@ -18,7 +18,7 @@ export async function updateTkoolmvNamagameKitRuntime(moduleDirPath: string): Pr
 	if (!fs.existsSync(moduleDirPath)) {
 		fs.mkdirSync(moduleDirPath, { recursive: true });
 	}
-	await installModule(moduleName, latestVersion, `tkoolmv-namagame-runtime-${latestVersion}.zip`, moduleDirPath);
+	await installModule(moduleName, latestVersion, `tkoolmv-namagame-runtime.zip`, moduleDirPath);
 	fs.writeFileSync(versionTxtPath, latestVersion);
 }
 


### PR DESCRIPTION
### やったこと
* https://github.com/akashic-games/tkoolmv-namagame-runtime/pull/7 に合わせて、コンバータがruntimeのReleaseNoteからダウンロードするzip名をリネームしました