### PR TITLE
prohibited access to external scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "electron-log": "^4.4.8",
         "electron-updater": "^6.1.7",
         "express": "^4.18.2",
+        "helmet": "^8.1.0",
         "image-size": "^1.0.2",
         "music-metadata": "^7.14.0",
         "sharp": "^0.32.6",
@@ -7702,6 +7703,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hmac-drbg": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "electron-log": "^4.4.8",
     "electron-updater": "^6.1.7",
     "express": "^4.18.2",
+    "helmet": "^8.1.0",
     "image-size": "^1.0.2",
     "music-metadata": "^7.14.0",
     "sharp": "^0.32.6",

--- a/src/main/playground/createServer.ts
+++ b/src/main/playground/createServer.ts
@@ -1,6 +1,7 @@
 import * as http from "http";
 import * as path from "path";
 import * as express from "express";
+import * as helmet from "helmet";
 
 export interface PlaygroundServer {
 	server: http.Server;
@@ -15,6 +16,22 @@ export function createPlaygroundServer(gameBaseDir: string, audioBaseDir?: strin
 		res.header("Access-Control-Allow-Credentials", "true");
 		next();
 	});
+	app.use(
+		helmet.contentSecurityPolicy({
+			directives: {
+				defaultSrc: ["'none'"],
+				scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+				connectSrc: ["'self'"],
+				imgSrc: ["'self'", "data:"],
+				mediaSrc: ["'self'"],
+				styleSrc: ["'self'", "'unsafe-inline'"],
+				baseUri: ["'none'"],
+				formAction: ["'none'"],
+				workerSrc: ["'self'"],
+				frameAncestors: ["'self'", "file://*"]
+			}
+		})
+	);
 	app.use("/playground/", express.static(playgroundDst));
 	app.use("/games/", express.static(gameBaseDir));
 	if (audioBaseDir) {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -119,6 +119,9 @@ window.addEventListener("load", () => {
 			iframElement.src = response.gameContentUrl;
 			iframElement.width = "100%";
 			iframElement.height = "100%";
+			// スクリプトの実行と同一オリジンリソースへのアクセス以外を許可しないようにsandbox属性を設定する
+			// sandboxはreadonlyなのでas anyとする
+			(iframElement as any).sandbox = "allow-scripts allow-same-origin";
 			dropZone.append(iframElement);
 			download.disabled = false;
 			reset.disabled = false;


### PR DESCRIPTION
### 概要
コンバーターの動作確認画面で正常に動作して、ニコニコ生放送環境では正常に動作しないコンテンツが見つかった。
これは対象のコンテンツが外部スクリプトを読み込んでいたためだった。
コンバーター側も生放送環境側に合わせて、外部スクリプトを読み込んでいるコンテンツを動作させるべきではないので、今回はそのように修正を行う。

### やったこと
- playgroundを立ち上げるサーバー側でCSPの設定
- クライアント側でplaygroundを動かすiframeにsandbox属性を付与する

### 動作確認内容
今回修正したコンバーターで以下のことを確認
- ニコニコ生放送環境で動作するコンテンツが、コンバーター上でも正常に動作すること
- ニコニコ生放送環境で動作しないコンテンツが、コンバーター上では正常に動作しないこと
  - 外部スクリプトの読み込みができないこと
  - コンテンツ中にiframeで任意のサイトの埋め込みができないこと 